### PR TITLE
Fix typos in thrown exceptions

### DIFF
--- a/src/PhpLicense.php
+++ b/src/PhpLicense.php
@@ -26,7 +26,7 @@ class PhpLicense
         openssl_free_key($key);
 
         if (!$success) {
-            throw new BaseException("OpenSSL: Enable to generate signature");
+            throw new BaseException("OpenSSL: Unable to generate signature");
         }
 
         $sign_b64 = base64_encode($signature);
@@ -56,7 +56,7 @@ class PhpLicense
         openssl_free_key($key);
 
         if (!$success) {
-            throw new BaseException("OpenSSL: Enable to generate signature");
+            throw new BaseException("OpenSSL: Unable to generate signature");
         }
 
         return json_decode($decryptedData, true);


### PR DESCRIPTION
The exception messages for the signature generation appear to be incorrect. This changes them from `Enable` to `Unable`. If they are already correct, feel free to close this PR. 👍

Closes #1